### PR TITLE
Fix for Qt5.6 on Ubuntu 16.04

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,13 @@ cmake_policy(SET CMP0043 NEW)
 
 SET( CMAKE_DISABLE_SOURCE_CHANGES ON )
 SET( CMAKE_DISABLE_IN_SOURCE_BUILD ON )
+SET( Qt5OpenGL_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5OpenGL )
+SET( Qt5Core_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5Core )
+SET( Qt5Gui_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5Gui )
+SET( Qt5Network_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5Network )
+SET( Qt5Widgets_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5Widgets )
+SET( Qt5Xml_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5Xml )
+SET( Qt5_DIR /opt/Qt5.6.1/5.6/gcc_64/lib/cmake/Qt5 )
 
 PROJECT( braingl )
 SET( BinName "${PROJECT_NAME}" )
@@ -73,7 +80,7 @@ INCLUDE( ${VTK_USE_FILE} )
 # ---------------------------------------------------------------------------------------------------------------------------------------------------
 # Setup QT5
 # ---------------------------------------------------------------------------------------------------------------------------------------------------
-FIND_PACKAGE( Qt5 REQUIRED COMPONENTS Core Gui Widgets OpenGL Xml WebKit )
+FIND_PACKAGE( Qt5 REQUIRED COMPONENTS Core Gui Widgets OpenGL Xml )
 
 # Resources
 SET(QtIcon_RCCS resources.qrc)
@@ -153,9 +160,9 @@ IF( NOT  APPLE )
 
     ReadProjectRevisionStatus()
 
-    QT5_USE_MODULES( ${BinName} Widgets OpenGL Network Xml WebKit WebKitWidgets )
+    QT5_USE_MODULES( ${BinName} Widgets OpenGL Network Xml  )
 
-    TARGET_LINK_LIBRARIES( ${BinName} ${VTK_LIBRARIES} z  )
+    TARGET_LINK_LIBRARIES( ${BinName} ${Qt5Gui_OPENGL_LIBRARIES} ${VTK_LIBRARIES} z  )
 ENDIF()
 
 
@@ -177,7 +184,7 @@ IF( APPLE )
     SET( MACOSX_BUNDLE_GUI_IDENTIFIER "de.braingl" )
     SET( MACOSX_BUNDLE_BUNDLE_NAME "${PROJECT_NAME}" )
     
-    QT5_USE_MODULES( ${BinName} Widgets OpenGL Network Xml WebKit WebKitWidgets )
+    QT5_USE_MODULES( ${BinName} Widgets OpenGL Network Xml )
     TARGET_LINK_LIBRARIES( ${BinName} ${OPENGL_LIBRARY} ${VTK_LIBRARIES} "-framework Foundation" "-framework Cocoa" z)
 
     # create self-contained application bundle with embedded Frameworks and dylibs

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -59,7 +59,7 @@
 #include "../io/statereader.h"
 
 #include <QAction>
-#include <QWebView>
+//#include <QWebView>
 #include <QGLFormat>
 #include <QKeySequence>
 
@@ -113,7 +113,7 @@ MainWindow::MainWindow( bool debug, bool resetSettings ) :
         loadSettings();
     }
 
-    m_tcpServer = new QTcpServer();
+/*    m_tcpServer = new QTcpServer();
     if ( !m_tcpServer->listen( QHostAddress( "127.0.0.1" ), 12345 ) )
     {
         qDebug() << "Unable to start the server: " << m_tcpServer->errorString();
@@ -123,7 +123,7 @@ MainWindow::MainWindow( bool debug, bool resetSettings ) :
     {
         connect( m_tcpServer, &QTcpServer::newConnection , this, &MainWindow::receiveTCP );
     }
-
+*/
 }
 
 void MainWindow::closeEvent( QCloseEvent *event )
@@ -1617,7 +1617,7 @@ void MainWindow::resetSettings()
 
 void MainWindow::slotDilbert()
 {
-    QWidget* widget = new QWidget();
+/*    QWidget* widget = new QWidget();
     QVBoxLayout* vLayout = new QVBoxLayout();
     vLayout->setContentsMargins( 1, 1, 1, 1 );
     vLayout->setSpacing( 1 );
@@ -1626,6 +1626,7 @@ void MainWindow::slotDilbert()
     vLayout->addWidget( wv );
     widget->setLayout( vLayout );
     widget->show();
+*/
 }
 
 void MainWindow::slotNew()
@@ -1700,16 +1701,17 @@ void MainWindow::newLabel()
 
 void MainWindow::receiveTCP()
 {
-    qDebug() << "something received!";
+/*    qDebug() << "something received!";
 
     m_clientConnection = m_tcpServer->nextPendingConnection();
     connect( m_clientConnection, &QTcpSocket::disconnected, m_clientConnection, &QTcpSocket::deleteLater );
     connect( m_clientConnection, &QTcpSocket::readyRead, this, &MainWindow::readTCP );
+*/
 }
 
 void MainWindow::readTCP()
 {
-    QString stuff = m_clientConnection->readAll();
+/*    QString stuff = m_clientConnection->readAll();
     qDebug() << stuff;
     QStringList sl = stuff.split( " " );
     float x = sl.at(0).toFloat();
@@ -1717,4 +1719,5 @@ void MainWindow::readTCP()
     Models::setGlobal( Fn::Property::G_SAGITTAL, x );
 
     Models::g()->submit();
+*/
 }


### PR DESCRIPTION
Hi, 
we compiled braingl on Ubuntu 16.04 using Qt5.6. 
QT5.6 was used to increase the performance by correctly processing the mouse events. QT5.6 does not support the WebKit, so we removed "dilbert" from the gui.
Best,
Alfred
